### PR TITLE
Fixed the balloon formula to reduce lift with velocity, not turn it off.

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/tournament/ship/tournamentShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/tournament/ship/tournamentShipControl.kt
@@ -62,7 +62,7 @@ class tournamentShipControl : ShipForcesInducer, ServerShipUser, Ticked {
             var tPValue = tournamentConfig.SERVER.BaseHeight - ((tHeight * tHeight) / 1000.0)
 
             if (vel.y() > 10.0)    {
-                tPValue = (-vel.y() * 0.25)
+                tPValue -= (vel.y() * 0.25)
             }
             if(tPValue <= 0){
                 tPValue = 0.0


### PR DESCRIPTION
tPValue used to be set to 0 whenever upwards velocity crossed 10. That caused severe wobble in the balloons. This changes code to what was probably intended, reducing lift by a factor of velocity, not cranking it to 0 instantly.